### PR TITLE
Allow failure for Python Nightly in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,9 @@ install:
 
 script: py.test  --cov-report term --cov=ga_solver
 
+jobs:
+  allow_failures:
+    - if: python = "nightly"
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script: py.test  --cov-report term --cov=ga_solver
 
 jobs:
   allow_failures:
-    - if: python = "nightly"
+    - python: "nightly"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- Once again, trying to allow failure for python nightly
- Add python nightly as optional step
